### PR TITLE
Add option for intermediate import groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Organizes Go imports into the following groups:
  - **other** - Anything not specifically called out in this list
  - **kubernetes** - Anything that starts with `k8s.io`
  - **openshift** - Anything that starts with `github.com/openshift`
+ - **intermediates** - Optional list of groups
  - **module** - Anything that is part of the current module
 
 ## <a name='Examplesortedimportblock'></a>Example sorted import block
@@ -64,12 +65,25 @@ Usage:
 
 Flags:
   -h, --help                             help for openshift-goimports
+  -i, --intermediates string             Space-separated list of names of go modules to put between openshift and module to organize. Example: github.com/thirdy/one thirdy.io/two (optional)
   -l, --list                             List files whose imports are not sorted without making changes
   -m, --module string                    The name of the go module. Example: github.com/example-org/example-repo (optional)
   -p, --path string                      The path to the go module to organize. Defaults to the current directory. (default ".") (optional)
   -d, --dry                              Dry run only, do not actually make any changes to files
   -v, --v Level                          number for the log level verbosity
 ```
+
+## Matching and Precedence
+
+Each group is identified by a pattern that is sought as a substring in the import path.  For example, the kubernetes group is defined by searching for the substring "k8s.io".  Multiple groups can match one import.  In such a case, the import is put into the first matching group in the following list.
+
+- the module to organize
+- the intermediate modules, in the order given on the command line
+- kubernetes
+- openshift
+- other
+
+An import whose path matches no other group's pattern is put in the standard group.
 
 ## <a name='Examples'></a>Examples
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Usage:
 
 Flags:
   -h, --help                             help for openshift-goimports
-  -i, --intermediates string             Space-separated list of names of go modules to put between openshift and module to organize. Example: github.com/thirdy/one thirdy.io/two (optional)
+  -i, --intermediate stringArray         Names of go modules to put between openshift and module to organize. Example usage: -i github.com/thirdy/one -i thirdy.io/two
   -l, --list                             List files whose imports are not sorted without making changes
   -m, --module string                    The name of the go module. Example: github.com/example-org/example-repo (optional)
   -p, --path string                      The path to the go module to organize. Defaults to the current directory. (default ".") (optional)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,15 +38,16 @@ import (
 )
 
 var (
-	module  string
-	path    string
-	dry     bool
-	list    bool
-	cfgFile string
-	wg      sync.WaitGroup
-	impLine = regexp.MustCompile(`^\s+(?:[\w\.]+\s+)?"(.+)"`)
-	vendor  = regexp.MustCompile(`vendor/`)
-	files   = make(chan string, 1000)
+	intermediatesList []string
+	module            string
+	path              string
+	dry               bool
+	list              bool
+	cfgFile           string
+	wg                sync.WaitGroup
+	impLine           = regexp.MustCompile(`^\s+(?:[\w\.]+\s+)?"(.+)"`)
+	vendor            = regexp.MustCompile(`vendor/`)
+	files             = make(chan string, 1000)
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -86,7 +87,7 @@ var rootCmd = &cobra.Command{
 
 		for i := 0; i < 10; i++ {
 			wg.Add(1)
-			go imports.Format(files, &wg, &module, &dry, &list)
+			go imports.Format(files, &wg, intermediatesList, &module, &dry, &list)
 		}
 
 		if s, err := os.Stat(path); err != nil {
@@ -141,6 +142,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.openshift-goimports.yaml)")
 
 	rootCmd.Flags().StringVarP(&path, "path", "p", "", "The path to the go module to organize. Defaults to the current directory.")
+	rootCmd.Flags().StringArrayVarP(&intermediatesList, "intermediate", "i", []string{}, "Names of go modules to put between openshift and module to organize. Example usage: -i github.com/thirdy/one -i thirdy.io/two")
 	rootCmd.Flags().StringVarP(&module, "module", "m", "", "The name of the go module. Example: github.com/example-org/example-repo")
 	rootCmd.Flags().BoolVarP(&list, "list", "l", false, "List files whose imports are not sorted without making changes")
 	rootCmd.Flags().BoolVarP(&dry, "dry", "d", false, "Dry run only, do not actually make any changes to files")

--- a/pkg/imports/format_test.go
+++ b/pkg/imports/format_test.go
@@ -1,0 +1,92 @@
+package imports
+
+import (
+	"os"
+	"sync"
+	"testing"
+)
+
+const inputFileContents = `package main
+
+import (
+	tf "thirdy.io/twofer"
+	"example.com/exampkg"
+	"github.com/random"
+	"thirdy.io/two"
+	t1 "github.com/thirdy.one"
+	"os"
+	"k8s.io/klog/v2"
+)
+
+func main() {
+	os.Exit(86)
+}
+`
+
+const expectedFileContents = `package main
+
+import (
+	"os"
+
+	"github.com/random"
+
+	"k8s.io/klog/v2"
+
+	"thirdy.io/two"
+	tf "thirdy.io/twofer"
+
+	t1 "github.com/thirdy.one"
+
+	"example.com/exampkg"
+)
+
+func main() {
+	os.Exit(86)
+}
+`
+
+const testFileName = "example.go"
+
+func TestFormat(t *testing.T) {
+	testDir, err := os.MkdirTemp("", "tools-test")
+	if err != nil {
+		t.Errorf("Failed to make temporary directory: %s", err)
+	}
+	defer os.RemoveAll(testDir)
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Errorf("Failed to read current working directory: %s", err)
+	}
+	defer os.Chdir(originalWD)
+	os.Chdir(testDir)
+	file, err := os.Create(testFileName)
+	if err != nil {
+		t.Errorf("Failed to create test input file: %s", err)
+	}
+	_, err = file.WriteString(inputFileContents)
+	if err != nil {
+		t.Errorf("Failed to write input file contents: %s", err)
+	}
+	err = file.Close()
+	if err != nil {
+		t.Errorf("Failed to close input file: %s", err)
+	}
+	filesChan := make(chan string)
+	exampleModule := "example.com/exampkg"
+	dry := false
+	list := false
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go Format(filesChan, &wg, []string{"thirdy.io/two", "github.com/thirdy.one"}, &exampleModule, &dry, &list)
+	filesChan <- testFileName
+	close(filesChan)
+	wg.Wait()
+	resultBytes, err := os.ReadFile(testFileName)
+	if err != nil {
+		t.Errorf("Failed to read test file: %s", err)
+	}
+	resultString := string(resultBytes)
+	if resultString != expectedFileContents {
+		t.Errorf("Expected %s but got %s", expectedFileContents, resultString)
+	}
+}


### PR DESCRIPTION
<!--

Before making a PR, please ensure that your branch is rebased to the latest upstream main.

-->

**Description of the change:**
This PR adds an option for the user to list additional groups to sort between openshift and the module to organize.

This PR also expands the README to explain that imports are classified by pattern search, and what happens for an import that matches multiple groups.

**Motivation for the change:**
It makes sense to organize imports into layers.  There may be more than one layer above Kubernetes/OpenShift.

The README was expanded because it was silent on an important aspect of this utility's behavior.

**Reviewer Checklist**
- [ ] Sufficient unit test coverage 
- [ ] README updated with relevent examples 
- [ ] Commit messages are sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->