### PR TITLE
Handle case of no go.mod in sight

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -191,7 +191,11 @@ func findGoModule(path string) (string, error) {
 		if _, err := os.Stat(modFilePath); !os.IsNotExist(err) {
 			break
 		}
+		prevPath := path
 		path = filepath.Dir(path)
+		if path == prevPath {
+			return "", nil
+		}
 	}
 	if path == "." {
 		return "", nil


### PR DESCRIPTION
<!--

Before making a PR, please ensure that your branch is rebased to the latest upstream main.

-->

**Description of the change:**
This PR updates the code that finds `go.mod` to handle the case where it is not found.

**Motivation for the change:**
Prior to this change, a search for a non-existent go.mod would be an infinite loop.  This is issue #17 .

**Reviewer Checklist**
- [ ] Sufficient unit test coverage 
- [ ] README updated with relevent examples 
- [ ] Commit messages are sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->